### PR TITLE
feat(pymongo): introduce `db.operation`, refactor `db.statement`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `opentelemetry-util-http` Added support for redacting specific url query string values and url credentials in instrumentations
   ([#3508](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3508))
-  
+- `opentelemetry-instrumentation-pymongo` `aggregate` and `getMore` capture statements support
+  ([#3601](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3601))
+
 ## Version 1.34.0/0.55b0 (2025-06-04)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `opentelemetry-instrumentation-pymongo` `aggregate` and `getMore` capture statements support
   ([#3601](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3601))
 
+### Breaking changes
+
+- `opentelemetry-instrumentation-pymongo` introduce `db.operation`, refactor `db.statement`, refactor span name
+  ([#3606](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3606))
+
 ## Version 1.34.0/0.55b0 (2025-06-04)
 
 ### Fixed

--- a/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/__init__.py
@@ -223,12 +223,14 @@ def _get_span_name(event: CommandEvent) -> str:
         return f"{event.database_name}.{collection}.{command_name}"
     return f"{event.database_name}.{command_name}"
 
+
 def _get_statement(event: CommandEvent) -> str:
     """Get the statement for a given pymongo event."""
     command_name = event.command_name
     command_attribute = COMMAND_TO_ATTRIBUTE_MAPPING.get(command_name)
     command = event.command.get(command_attribute)
     return f"{command}"
+
 
 def _get_span_dict_key(
     event: CommandEvent,

--- a/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/utils.py
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/src/opentelemetry/instrumentation/pymongo/utils.py
@@ -17,4 +17,6 @@ COMMAND_TO_ATTRIBUTE_MAPPING = {
     "delete": "deletes",
     "update": "updates",
     "find": "filter",
+    "getMore": "collection",
+    "aggregate": "pipeline",
 }

--- a/instrumentation/opentelemetry-instrumentation-pymongo/tests/test_pymongo.py
+++ b/instrumentation/opentelemetry-instrumentation-pymongo/tests/test_pymongo.py
@@ -62,7 +62,8 @@ class TestPymongo(TestBase):
         self.assertEqual(
             span.attributes[SpanAttributes.DB_NAME], "database_name"
         )
-        self.assertEqual(span.attributes[SpanAttributes.DB_STATEMENT], "find")
+        self.assertEqual(span.attributes[SpanAttributes.DB_OPERATION], "find")
+        self.assertNotIn(SpanAttributes.DB_STATEMENT, span.attributes)
         self.assertEqual(
             span.attributes[SpanAttributes.NET_PEER_NAME], "test.com"
         )
@@ -210,7 +211,10 @@ class TestPymongo(TestBase):
 
         self.assertEqual(
             span.attributes[SpanAttributes.DB_STATEMENT],
-            "getMore test_collection",
+            "test_collection",
+        )
+        self.assertEqual(
+            span.attributes[SpanAttributes.DB_OPERATION], "getMore"
         )
 
     def test_capture_statement_aggregate(self):
@@ -232,9 +236,12 @@ class TestPymongo(TestBase):
         self.assertEqual(len(spans_list), 1)
         span = spans_list[0]
 
-        expected_statement = f"aggregate {pipeline}"
+        expected_statement = f"{pipeline}"
         self.assertEqual(
             span.attributes[SpanAttributes.DB_STATEMENT], expected_statement
+        )
+        self.assertEqual(
+            span.attributes[SpanAttributes.DB_OPERATION], "aggregate"
         )
 
     def test_capture_statement_disabled_getmore(self):
@@ -253,8 +260,10 @@ class TestPymongo(TestBase):
         span = spans_list[0]
 
         self.assertEqual(
-            span.attributes[SpanAttributes.DB_STATEMENT], "getMore"
+            span.attributes[SpanAttributes.DB_OPERATION], "getMore"
         )
+
+        self.assertNotIn(SpanAttributes.DB_STATEMENT, span.attributes)
 
     def test_capture_statement_disabled_aggregate(self):
         pipeline = [{"$match": {"status": "active"}}]
@@ -273,8 +282,10 @@ class TestPymongo(TestBase):
         span = spans_list[0]
 
         self.assertEqual(
-            span.attributes[SpanAttributes.DB_STATEMENT], "aggregate"
+            span.attributes[SpanAttributes.DB_OPERATION], "aggregate"
         )
+
+        self.assertNotIn(SpanAttributes.DB_STATEMENT, span.attributes)
 
 
 class MockCommand:

--- a/tests/opentelemetry-docker-tests/tests/pymongo/test_pymongo_functional.py
+++ b/tests/opentelemetry-docker-tests/tests/pymongo/test_pymongo_functional.py
@@ -45,7 +45,7 @@ class TestFunctionalPymongo(TestBase):
         self.instrumentor.uninstrument()
         super().tearDown()
 
-    def validate_spans(self, expected_db_statement):
+    def validate_spans(self, expected_db_operation, expected_db_statement = None):
         spans = self.memory_exporter.get_finished_spans()
         self.assertEqual(len(spans), 2)
         for span in spans:
@@ -74,7 +74,11 @@ class TestFunctionalPymongo(TestBase):
             MONGODB_COLLECTION_NAME,
         )
         self.assertEqual(
-            pymongo_span.attributes[SpanAttributes.DB_STATEMENT],
+            pymongo_span.attributes[SpanAttributes.DB_OPERATION],
+            expected_db_operation,
+        )
+        self.assertEqual(
+            pymongo_span.attributes.get(SpanAttributes.DB_STATEMENT, None),
             expected_db_statement,
         )
 
@@ -86,11 +90,12 @@ class TestFunctionalPymongo(TestBase):
             )
             insert_result_id = insert_result.inserted_id
 
+        expected_db_operation = "insert"
         expected_db_statement = (
-            f"insert [{{'name': 'testName', 'value': 'testValue', '_id': "
+            f"[{{'name': 'testName', 'value': 'testValue', '_id': "
             f"ObjectId('{insert_result_id}')}}]"
         )
-        self.validate_spans(expected_db_statement)
+        self.validate_spans(expected_db_operation, expected_db_statement)
 
     def test_update(self):
         """Should create a child span for update"""
@@ -99,29 +104,32 @@ class TestFunctionalPymongo(TestBase):
                 {"name": "testName"}, {"$set": {"value": "someOtherValue"}}
             )
 
+        expected_db_operation = "update"
         expected_db_statement = (
-            "update [SON([('q', {'name': 'testName'}), ('u', "
+            "[SON([('q', {'name': 'testName'}), ('u', "
             "{'$set': {'value': 'someOtherValue'}}), ('multi', False), ('upsert', False)])]"
         )
-        self.validate_spans(expected_db_statement)
+        self.validate_spans(expected_db_operation, expected_db_statement)
 
     def test_find(self):
         """Should create a child span for find"""
         with self._tracer.start_as_current_span("rootSpan"):
             self._collection.find_one({"name": "testName"})
 
-        expected_db_statement = "find {'name': 'testName'}"
-        self.validate_spans(expected_db_statement)
+        expected_db_operation = "find"
+        expected_db_statement = "{'name': 'testName'}"
+        self.validate_spans(expected_db_operation, expected_db_statement)
 
     def test_delete(self):
         """Should create a child span for delete"""
         with self._tracer.start_as_current_span("rootSpan"):
             self._collection.delete_one({"name": "testName"})
 
+        expected_db_operation = "delete"
         expected_db_statement = (
-            "delete [SON([('q', {'name': 'testName'}), ('limit', 1)])]"
+            "[SON([('q', {'name': 'testName'}), ('limit', 1)])]"
         )
-        self.validate_spans(expected_db_statement)
+        self.validate_spans(expected_db_operation, expected_db_statement)
 
     def test_find_without_capture_statement(self):
         """Should create a child span for find"""
@@ -130,8 +138,9 @@ class TestFunctionalPymongo(TestBase):
         with self._tracer.start_as_current_span("rootSpan"):
             self._collection.find_one({"name": "testName"})
 
-        expected_db_statement = "find"
-        self.validate_spans(expected_db_statement)
+        expected_db_operation = "find"
+        expected_db_statement = None
+        self.validate_spans(expected_db_operation, expected_db_statement)
 
     def test_uninstrument(self):
         # check that integration is working


### PR DESCRIPTION
# Description

This change updates the opentelemetry-instrumentation-pymongo to better align with OpenTelemetry semantic conventions and the behavior of other language instrumentations (e.g., NodeJS).


The key changes are:
 - The `db.operation` attribute is now used to record the MongoDB command name (e.g., find, insert).
 - The `db.statement` attribute is no longer populated by default. It is only recorded if the `capture_statement = True` option is passed to the instrumentor.
 - The span name has been made more specific, changing from `{db_name}.{command}` to `{db_name}.{collection}.{command}` when a collection is present.

This provides more consistent and conventional telemetry data for MongoDB operations.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

The existing unit tests in instrumentation/opentelemetry-instrumentation-pymongo/tests/test_pymongo.py have been updated to reflect these changes.

Specifically, the tests now verify:
 - `db.operation` is correctly set with the command name.
 - `db.statement` is not present on the span by default.
 - When `capture_statement = True` is enabled, `db.statement` is correctly populated with the full command statement.
 - The span name is correctly formatted.

All tests were run and passed using the project's tox configuration:

`tox -e test-pymongo`

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
